### PR TITLE
Fix display of UI and IntelliSense in Visual Studio 2017

### DIFF
--- a/Python/Templates/IronPython/ProjectTemplates/Python/WpfProject/WpfApp.pyproj
+++ b/Python/Templates/IronPython/ProjectTemplates/Python/WpfProject/WpfApp.pyproj
@@ -33,7 +33,7 @@
       <Name>PresentationCore</Name>
       <Private>False</Private>
     </Reference>
-    <Reference Include="PresentationFramework, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+    <Reference Include="PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <Name>PresentationFramework</Name>
       <Private>False</Private>
     </Reference>

--- a/Python/Templates/IronPython/ProjectTemplates/Python/WpfProject/WpfApp.pyproj
+++ b/Python/Templates/IronPython/ProjectTemplates/Python/WpfProject/WpfApp.pyproj
@@ -37,7 +37,7 @@
       <Name>PresentationFramework</Name>
       <Private>False</Private>
     </Reference>
-    <Reference Include="WindowsBase, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+    <Reference Include="WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <Name>WindowsBase</Name>
       <Private>False</Private>
     </Reference>


### PR DESCRIPTION
It seems that in Visual Studio 2017 I need to explicitly add PresentationFramework 4.0.0.0 as a reference to Python projects to display the UI in the editor window and get IntelliSense working in XAML.